### PR TITLE
Edit stream without fully reading it into single dataset

### DIFF
--- a/offline_tools/redactor/lib/build.gradle
+++ b/offline_tools/redactor/lib/build.gradle
@@ -20,6 +20,10 @@ plugins {
     id 'maven'
 }
 
+group = "com.google.cloud.healthcare.deid"
+archivesBaseName = "redactor"
+version = "0.1.0"
+
 buildDir = "/tmp/gradle_build/redactor"
 
 dependencies {

--- a/offline_tools/redactor/lib/build.gradle
+++ b/offline_tools/redactor/lib/build.gradle
@@ -17,6 +17,7 @@
 plugins {
     id 'java-library'
     id 'com.google.protobuf' version "0.8.7"
+    id 'maven'
 }
 
 buildDir = "/tmp/gradle_build/redactor"

--- a/offline_tools/redactor/lib/src/main/java/com/google/cloud/healthcare/deid/redactor/AbstractDicomRedactor.java
+++ b/offline_tools/redactor/lib/src/main/java/com/google/cloud/healthcare/deid/redactor/AbstractDicomRedactor.java
@@ -1,0 +1,180 @@
+package com.google.cloud.healthcare.deid.redactor;
+
+
+import com.google.cloud.healthcare.deid.redactor.protos.DicomConfigProtos.DicomConfig;
+import com.google.protobuf.TextFormat;
+import java.io.BufferedReader;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.dcm4che3.data.Attributes;
+import org.dcm4che3.data.Attributes.Visitor;
+import org.dcm4che3.data.StandardElementDictionary;
+import org.dcm4che3.data.Tag;
+import org.dcm4che3.data.UID;
+import org.dcm4che3.data.VR;
+import org.dcm4che3.imageio.codec.TransferSyntaxType;
+import org.dcm4che3.io.BulkDataDescriptor;
+import org.dcm4che3.io.DicomInputStream;
+import org.dcm4che3.io.DicomInputStream.IncludeBulkData;
+import org.dcm4che3.io.DicomOutputStream;
+import org.dcm4che3.util.UIDUtils;
+
+public abstract class AbstractDicomRedactor implements IDicomRedactor{
+
+  /**
+   * RedactorSettings holds the settings for DICOM redaction.
+   */
+  protected final class RedactorSettings {
+
+    public Set<Integer> tagSet;
+    public boolean isKeepList;
+  }
+
+  protected final RedactorSettings settings;
+  // Replace SOPInstanceUID, StudyInstanceUID, SeriesInstanceUID, and MediaStorageSOPInstanceUID.
+  protected static final List<Integer> replaceUIDs =
+      new ArrayList<>(Arrays.asList(0x00080018, 0x0020000D, 0x0020000E, 0x00020003));
+  protected static final String CHC_BASIC_FILE = "chc_basic.textproto";
+
+  /**
+   * Iterates over all tags in a DICOM file and redacts based on tagSet. If isKeepList is true, the
+   * tags in the tagSet are kept untouched and all others are removed. If isKeepList is false, the
+   * tags in the tagSet are removed and all others are kept untouched.
+   */
+  protected class RedactVisitor implements Visitor {
+    protected RedactVisitor(){
+
+    }
+
+    @Override
+    public boolean visit(Attributes attrs, int tag, VR vr, Object value) {
+      if (replaceUIDs.contains(tag)) {
+        AbstractDicomRedactor.this.regenUID(attrs, tag);
+        return true;
+      }
+      if (shouldRemoveTag(tag)) {
+        attrs.setNull(tag, vr);
+      }
+      return true;
+    }
+  }
+
+  /**
+   * Constructs a DicomRedactor for the provided config.
+   *
+   * @throws IllegalArgumentException if the configuration structure is invalid.
+   */
+  public AbstractDicomRedactor(DicomConfig config) throws Exception {
+    this.settings = parseConfig(config);
+  }
+
+  /**
+   * Constructs a DicomRedactor for the provided config and prefix for UID replacement.
+   *
+   * @throws IllegalArgumentException if the configuration structure is invalid.
+   */
+  public AbstractDicomRedactor(DicomConfig config, String prefix) throws Exception {
+    this(config);
+    UIDUtils.setRoot(prefix);
+  }
+
+  /**
+   * Parses DicomConfig proto to produce a RedactorSettings object.
+   *
+   * @throws IllegalArgumentException if the configuration structure or tags are invalid.
+   * @throws InternalError if there is an exception trying to load a predefined profile.
+   */
+  private RedactorSettings parseConfig(DicomConfig config)
+      throws IllegalArgumentException {
+    RedactorSettings ret = new RedactorSettings();
+    DicomConfig.TagFilterList tags;
+    switch (config.getTagFilterCase()) {
+      case KEEP_LIST:
+        ret.isKeepList = true;
+        tags = config.getKeepList();
+        break;
+      case REMOVE_LIST:
+        ret.isKeepList = false;
+        tags = config.getRemoveList();
+        break;
+      case FILTER_PROFILE:
+        switch (config.getFilterProfile()) {
+          case TAG_FILTER_PROFILE_UNSPECIFIED:
+          case CHC_BASIC:
+            DicomConfig.Builder configBuilder = DicomConfig.newBuilder();
+            TextFormat.Parser parser = TextFormat.Parser.newBuilder().build();
+            final StringBuilder protoString = new StringBuilder();
+            try (BufferedReader protoReader = new BufferedReader(new InputStreamReader(
+                DicomRedactor.class.getClassLoader().getResourceAsStream(CHC_BASIC_FILE)))) {
+              String line;
+              while (true) {
+                line = protoReader.readLine();
+                if (line == null) {
+                  break;
+                }
+                protoString.append(line).append('\n');
+              }
+              parser.merge(protoString.toString(), configBuilder);
+              if (configBuilder.hasFilterProfile()) {
+                throw new InternalError("Profile cannot point to another profile");
+              }
+            } catch (Exception e) {
+              throw new InternalError("Failed to load selected profile.", e);
+            }
+            return parseConfig(configBuilder.build());
+          default:
+            throw new IllegalArgumentException("Config specifies an unrecognized profile.");
+        }
+      default:
+        throw new IllegalArgumentException("Config does not specify a tag filtration method.");
+    }
+    ret.tagSet = new HashSet<Integer>();
+    for (String tag : tags.getTagsList()) {
+      int tagID = this.toTagID(tag);
+      ret.tagSet.add(tagID);
+    }
+    return ret;
+  }
+
+  /**
+   * Converts tag keywords and id strings to tag IDs.
+   *
+   * @throws IllegalArgumentException if the tag cannot be converted.
+   */
+  protected int toTagID(String tag) throws IllegalArgumentException {
+    // Attempt to parse as a tag keyword.
+    int tagNum = StandardElementDictionary.tagForKeyword(tag, null /* privateCreatorID */);
+    if (tagNum != -1) {
+      return tagNum;
+    }
+    // Attempt to parse as a tag id in string form.
+    int ret;
+    try {
+      ret = Integer.parseInt(tag, 16);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(String.format("Failed to recognize DICOM tag: %s", tag));
+    }
+    return ret;
+  }
+
+  /**
+   * Regenerates UID for the given tag. Does not check VR of tag to ensure it is a UID.
+   */
+  protected void regenUID(Attributes attrs, int tag) {
+    String newUID = UIDUtils.createNameBasedUID(attrs.getString(tag).getBytes());
+    attrs.setString(tag, VR.UI, newUID);
+  }
+
+  protected boolean shouldRemoveTag(int tag) {
+    return (settings.isKeepList && !settings.tagSet.contains(tag))
+        || (!settings.isKeepList && settings.tagSet.contains(tag));
+  }
+}

--- a/offline_tools/redactor/lib/src/main/java/com/google/cloud/healthcare/deid/redactor/DicomRedactor.java
+++ b/offline_tools/redactor/lib/src/main/java/com/google/cloud/healthcare/deid/redactor/DicomRedactor.java
@@ -17,21 +17,10 @@
 package com.google.cloud.healthcare.deid.redactor;
 
 import com.google.cloud.healthcare.deid.redactor.protos.DicomConfigProtos.DicomConfig;
-import com.google.protobuf.TextFormat;
-import java.io.BufferedReader;
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import org.dcm4che3.data.Attributes;
-import org.dcm4che3.data.Attributes.Visitor;
-import org.dcm4che3.data.StandardElementDictionary;
 import org.dcm4che3.data.Tag;
 import org.dcm4che3.data.UID;
 import org.dcm4che3.data.VR;
@@ -40,155 +29,37 @@ import org.dcm4che3.io.BulkDataDescriptor;
 import org.dcm4che3.io.DicomInputStream;
 import org.dcm4che3.io.DicomInputStream.IncludeBulkData;
 import org.dcm4che3.io.DicomOutputStream;
-import org.dcm4che3.util.UIDUtils;
 
-/** DicomRedactor implements basic DICOM redaction. */
-public class DicomRedactor {
-
-  private static final int BATCH_SIZE = 8192;
-
-  /** RedactorSettings holds the settings for DICOM redaction. */
-  private final class RedactorSettings {
-    public Set<Integer> tagSet;
-    public boolean isKeepList;
-  }
-
-  private final RedactorSettings settings;
-  // Replace SOPInstanceUID, StudyInstanceUID, SeriesInstanceUID, and MediaStorageSOPInstanceUID.
-  private static final List<Integer> replaceUIDs =
-      new ArrayList<>(Arrays.asList(0x00080018, 0x0020000D, 0x0020000E, 0x00020003));
-  private static final String CHC_BASIC_FILE = "chc_basic.textproto";
-
-   /**
-   *  Iterates over all tags in a DICOM file and redacts based on tagSet. If isKeepList is true, the
-   *  tags in the tagSet are kept untouched and all others are removed. If isKeepList is false, the
-   *  tags in the tagSet are removed and all others are kept untouched.
-   */
-  private class RedactVisitor implements Visitor {
-    @Override
-    public boolean visit(Attributes attrs, int tag, VR vr, Object value) {
-      if (replaceUIDs.contains(tag)) {
-        DicomRedactor.this.regenUID(attrs, tag);
-        return true;
-      }
-      if (shouldRemoveTag(tag)) {
-        attrs.setNull(tag, vr);
-      }
-      return true;
-    }
-  }
+/**
+ * DicomRedactor implements basic DICOM redaction.
+ */
+public class DicomRedactor extends AbstractDicomRedactor {
 
   /**
    * Constructs a DicomRedactor for the provided config.
+   *
    * @throws IllegalArgumentException if the configuration structure is invalid.
    */
   public DicomRedactor(DicomConfig config) throws Exception {
-    this.settings = parseConfig(config);
+    super(config);
   }
 
   /**
    * Constructs a DicomRedactor for the provided config and prefix for UID replacement.
+   *
    * @throws IllegalArgumentException if the configuration structure is invalid.
    */
   public DicomRedactor(DicomConfig config, String prefix) throws Exception {
-    this(config);
-    UIDUtils.setRoot(prefix);
-  }
-
-  /**
-   * Parses DicomConfig proto to produce a RedactorSettings object.
-   * @throws IllegalArgumentException if the configuration structure or tags are invalid.
-   * @throws InternalError if there is an exception trying to load a predefined profile.
-   */
-  private RedactorSettings parseConfig(DicomConfig config) throws IllegalArgumentException {
-    RedactorSettings ret = new RedactorSettings();
-    DicomConfig.TagFilterList tags;
-    switch(config.getTagFilterCase()) {
-      case KEEP_LIST:
-        ret.isKeepList = true;
-        tags = config.getKeepList();
-        break;
-      case REMOVE_LIST:
-        ret.isKeepList = false;
-        tags = config.getRemoveList();
-        break;
-      case FILTER_PROFILE:
-        switch(config.getFilterProfile()) {
-          case TAG_FILTER_PROFILE_UNSPECIFIED:
-          case CHC_BASIC:
-            DicomConfig.Builder configBuilder = DicomConfig.newBuilder();
-            TextFormat.Parser parser = TextFormat.Parser.newBuilder().build();
-            final StringBuilder protoString = new StringBuilder();
-            try (BufferedReader protoReader = new BufferedReader(new InputStreamReader(
-                DicomRedactor.class.getClassLoader().getResourceAsStream(CHC_BASIC_FILE)))) {
-              String line;
-              while (true) {
-                line = protoReader.readLine();
-                if (line == null) {
-                  break;
-                }
-                protoString.append(line).append('\n');
-              }
-              parser.merge(protoString.toString(), configBuilder);
-              if (configBuilder.hasFilterProfile()) {
-                throw new InternalError("Profile cannot point to another profile");
-              }
-            } catch (Exception e) {
-              throw new InternalError("Failed to load selected profile.", e);
-            }
-            return parseConfig(configBuilder.build());
-          default:
-            throw new IllegalArgumentException("Config specifies an unrecognized profile.");
-        }
-      default:
-        throw new IllegalArgumentException("Config does not specify a tag filtration method.");
-    }
-    ret.tagSet = new HashSet<Integer>();
-    for (String tag : tags.getTagsList()) {
-      int tagID = this.toTagID(tag);
-      ret.tagSet.add(tagID);
-    }
-    return ret;
-  }
-
-  /**
-   * Converts tag keywords and id strings to tag IDs.
-   * @throws IllegalArgumentException if the tag cannot be converted.
-   */
-  private int toTagID(String tag) throws IllegalArgumentException {
-    // Attempt to parse as a tag keyword.
-    int tagNum = StandardElementDictionary.tagForKeyword(tag, null /* privateCreatorID */);
-    if (tagNum != -1) {
-      return tagNum;
-    }
-    // Attempt to parse as a tag id in string form.
-    int ret;
-    try {
-      ret = Integer.parseInt(tag, 16);
-    } catch (Exception e) {
-      throw new IllegalArgumentException(String.format("Failed to recognize DICOM tag: %s", tag));
-    }
-    return ret;
-  }
-
-  /** Regenerates UID for the given tag. Does not check VR of tag to ensure it is a UID. */
-  private void regenUID(Attributes attrs, int tag) {
-    String newUID = UIDUtils.createNameBasedUID(attrs.getString(tag).getBytes());
-    attrs.setString(tag, VR.UI, newUID);
-  }
-
-  private boolean shouldRemoveTag(int tag) {
-    return (settings.isKeepList && !settings.tagSet.contains(tag))
-        || (!settings.isKeepList && settings.tagSet.contains(tag));
+    super(config, prefix);
   }
 
   /**
    * Redact the given DICOM input stream, and write the result to the given output stream.
+   *
    * @throws IOException if the input stream cannot be read or the output stream cannot be written.
    * @throws IllegalArgumentException if there is an error redacting the object.
    */
-  @Deprecated
-  public void redactWithFullRead(InputStream inStream, OutputStream outStream)
+  public void redact(InputStream inStream, OutputStream outStream)
       throws IOException, IllegalArgumentException {
     Attributes metadata, dataset;
     try (DicomInputStream dicomInputStream = new DicomInputStream(inStream)) {
@@ -224,67 +95,6 @@ public class DicomRedactor {
       dicomOutputStream.writeDataset(metadata, dataset);
     } catch (Exception e) {
       throw new IOException("Failed to write output DICOM object", e);
-    }
-  }
-
-  /**
-   * Redact the given DICOM input stream, and write the result to the given output stream. Without
-   * reading whole dataset in one go.
-   *
-   * @throws IOException if the input stream cannot be read or the output stream cannot be written.
-   * @throws IllegalArgumentException if there is an error redacting the object.
-   */
-  public void redact(InputStream inStream, OutputStream outStream)
-      throws IOException, IllegalArgumentException {
-    Attributes metadata, dataset;
-    RedactVisitor visitor = new RedactVisitor();
-    try (DicomInputStream dicomInputStream = new DicomInputStream(inStream)) {
-      try (DicomOutputStream dicomOutputStream = new DicomOutputStream(outStream,
-          UID.ExplicitVRLittleEndian)) {
-        try {
-          dicomInputStream.setIncludeBulkData(IncludeBulkData.YES);
-          dicomInputStream.setBulkDataDescriptor(BulkDataDescriptor.PIXELDATA);
-          metadata = dicomInputStream.getFileMetaInformation();
-
-          // Update UID in metadata.
-          regenUID(metadata, Tag.MediaStorageSOPInstanceUID);
-
-          // Overwrite transfer syntax if PixelData is to be removed.
-          String ts = metadata.getString(Tag.TransferSyntaxUID);
-          if (shouldRemoveTag(toTagID("PixelData"))
-              && (TransferSyntaxType.forUID(ts) != TransferSyntaxType.NATIVE)) {
-            metadata.setString(Tag.TransferSyntaxUID, VR.UI, UID.ExplicitVRLittleEndian);
-          }
-        } catch (Exception e) {
-          throw new IOException("Failed to initialize redactor", e);
-        }
-
-        boolean firstDataset = true;
-        boolean lastDataset = false;
-        while (!lastDataset) {
-          try {
-            dicomInputStream.mark(BATCH_SIZE);
-            dataset = dicomInputStream.readDataset(BATCH_SIZE, -1);
-          } catch (EOFException e) {
-            dicomInputStream.reset();
-            dataset = dicomInputStream.readDataset(-1, -1);
-            lastDataset = true;
-          }
-
-          try {
-            dataset.accept(visitor, false);
-          } catch (Exception e) {
-            throw new IllegalArgumentException("Failed to redact one or more tags", e);
-          }
-
-          if (firstDataset) {
-            firstDataset = false;
-            dicomOutputStream.writeDataset(metadata, dataset);
-          } else {
-            dicomOutputStream.writeDataset(null, dataset);
-          }
-        }
-      }
     }
   }
 }

--- a/offline_tools/redactor/lib/src/main/java/com/google/cloud/healthcare/deid/redactor/DicomRedactor.java
+++ b/offline_tools/redactor/lib/src/main/java/com/google/cloud/healthcare/deid/redactor/DicomRedactor.java
@@ -19,6 +19,7 @@ package com.google.cloud.healthcare.deid.redactor;
 import com.google.cloud.healthcare.deid.redactor.protos.DicomConfigProtos.DicomConfig;
 import com.google.protobuf.TextFormat;
 import java.io.BufferedReader;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -44,6 +45,8 @@ import org.dcm4che3.util.UIDUtils;
 /** DicomRedactor implements basic DICOM redaction. */
 public class DicomRedactor {
 
+  private static final int BATCH_SIZE = 8192;
+
   /** RedactorSettings holds the settings for DICOM redaction. */
   private final class RedactorSettings {
     public Set<Integer> tagSet;
@@ -68,8 +71,7 @@ public class DicomRedactor {
         DicomRedactor.this.regenUID(attrs, tag);
         return true;
       }
-      if ((settings.isKeepList && !settings.tagSet.contains(tag))
-              || (!settings.isKeepList && settings.tagSet.contains(tag))) {
+      if (shouldRemoveTag(tag)) {
         attrs.setNull(tag, vr);
       }
       return true;
@@ -175,12 +177,18 @@ public class DicomRedactor {
     attrs.setString(tag, VR.UI, newUID);
   }
 
+  private boolean shouldRemoveTag(int tag) {
+    return (settings.isKeepList && !settings.tagSet.contains(tag))
+        || (!settings.isKeepList && settings.tagSet.contains(tag));
+  }
+
   /**
    * Redact the given DICOM input stream, and write the result to the given output stream.
    * @throws IOException if the input stream cannot be read or the output stream cannot be written.
    * @throws IllegalArgumentException if there is an error redacting the object.
    */
-  public void redact(InputStream inStream, OutputStream outStream)
+  @Deprecated
+  public void redactWithFullRead(InputStream inStream, OutputStream outStream)
       throws IOException, IllegalArgumentException {
     Attributes metadata, dataset;
     try (DicomInputStream dicomInputStream = new DicomInputStream(inStream)) {
@@ -216,6 +224,67 @@ public class DicomRedactor {
       dicomOutputStream.writeDataset(metadata, dataset);
     } catch (Exception e) {
       throw new IOException("Failed to write output DICOM object", e);
+    }
+  }
+
+  /**
+   * Redact the given DICOM input stream, and write the result to the given output stream. Without
+   * reading whole dataset in one go.
+   *
+   * @throws IOException if the input stream cannot be read or the output stream cannot be written.
+   * @throws IllegalArgumentException if there is an error redacting the object.
+   */
+  public void redact(InputStream inStream, OutputStream outStream)
+      throws IOException, IllegalArgumentException {
+    Attributes metadata, dataset;
+    RedactVisitor visitor = new RedactVisitor();
+    try (DicomInputStream dicomInputStream = new DicomInputStream(inStream)) {
+      try (DicomOutputStream dicomOutputStream = new DicomOutputStream(outStream,
+          UID.ExplicitVRLittleEndian)) {
+        try {
+          dicomInputStream.setIncludeBulkData(IncludeBulkData.YES);
+          dicomInputStream.setBulkDataDescriptor(BulkDataDescriptor.PIXELDATA);
+          metadata = dicomInputStream.getFileMetaInformation();
+
+          // Update UID in metadata.
+          regenUID(metadata, Tag.MediaStorageSOPInstanceUID);
+
+          // Overwrite transfer syntax if PixelData is to be removed.
+          String ts = metadata.getString(Tag.TransferSyntaxUID);
+          if (shouldRemoveTag(toTagID("PixelData"))
+              && (TransferSyntaxType.forUID(ts) != TransferSyntaxType.NATIVE)) {
+            metadata.setString(Tag.TransferSyntaxUID, VR.UI, UID.ExplicitVRLittleEndian);
+          }
+        } catch (Exception e) {
+          throw new IOException("Failed to initialize redactor", e);
+        }
+
+        boolean firstDataset = true;
+        boolean lastDataset = false;
+        while (!lastDataset) {
+          try {
+            dicomInputStream.mark(BATCH_SIZE);
+            dataset = dicomInputStream.readDataset(BATCH_SIZE, -1);
+          } catch (EOFException e) {
+            dicomInputStream.reset();
+            dataset = dicomInputStream.readDataset(-1, -1);
+            lastDataset = true;
+          }
+
+          try {
+            dataset.accept(visitor, false);
+          } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to redact one or more tags", e);
+          }
+
+          if (firstDataset) {
+            firstDataset = false;
+            dicomOutputStream.writeDataset(metadata, dataset);
+          } else {
+            dicomOutputStream.writeDataset(null, dataset);
+          }
+        }
+      }
     }
   }
 }

--- a/offline_tools/redactor/lib/src/main/java/com/google/cloud/healthcare/deid/redactor/IDicomRedactor.java
+++ b/offline_tools/redactor/lib/src/main/java/com/google/cloud/healthcare/deid/redactor/IDicomRedactor.java
@@ -1,0 +1,11 @@
+package com.google.cloud.healthcare.deid.redactor;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public interface IDicomRedactor {
+  public void redact(InputStream inStream, OutputStream outStream)
+      throws IOException, IllegalArgumentException;
+
+}

--- a/offline_tools/redactor/lib/src/main/java/com/google/cloud/healthcare/deid/redactor/StreamDicomRedactor.java
+++ b/offline_tools/redactor/lib/src/main/java/com/google/cloud/healthcare/deid/redactor/StreamDicomRedactor.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.healthcare.deid.redactor;
+
+import com.google.cloud.healthcare.deid.redactor.protos.DicomConfigProtos.DicomConfig;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.dcm4che3.data.Attributes;
+import org.dcm4che3.data.Tag;
+import org.dcm4che3.data.UID;
+import org.dcm4che3.data.VR;
+import org.dcm4che3.imageio.codec.TransferSyntaxType;
+import org.dcm4che3.io.BulkDataDescriptor;
+import org.dcm4che3.io.DicomInputStream;
+import org.dcm4che3.io.DicomInputStream.IncludeBulkData;
+import org.dcm4che3.io.DicomOutputStream;
+
+/**
+ * StreamDicomRedactor implements basic DICOM redaction without fully reading input stream in one
+ * pass
+ */
+public class StreamDicomRedactor extends AbstractDicomRedactor {
+
+  private static final int BATCH_SIZE = 8192;
+
+  /**
+   * Constructs a StreamDicomRedactor for the provided config.
+   *
+   * @throws IllegalArgumentException if the configuration structure is invalid.
+   */
+  public StreamDicomRedactor(DicomConfig config) throws Exception {
+    super(config);
+  }
+
+  /**
+   * Constructs a StreamDicomRedactor for the provided config and prefix for UID replacement.
+   *
+   * @throws IllegalArgumentException if the configuration structure is invalid.
+   */
+  public StreamDicomRedactor(DicomConfig config, String prefix) throws Exception {
+    super(config, prefix);
+  }
+
+  /**
+   * Redact the given DICOM input stream, and write the result to the given output stream. Without
+   * reading whole dataset in one go. Drawback: will parse last dataset twice.
+   * Inputstream.available can return 0 instead of -1 for undeterminted length streams, so can't
+   * relied upon.
+   *
+   * @throws IOException if the input stream cannot be read or the output stream cannot be written.
+   * @throws IllegalArgumentException if there is an error redacting the object.
+   */
+  public void redact(InputStream inStream, OutputStream outStream)
+      throws IOException, IllegalArgumentException {
+    Attributes metadata, dataset;
+    RedactVisitor visitor = new RedactVisitor();
+    try (DicomInputStream dicomInputStream = new DicomInputStream(inStream)) {
+      try (DicomOutputStream dicomOutputStream = new DicomOutputStream(outStream,
+          UID.ExplicitVRLittleEndian)) {
+        try {
+          dicomInputStream.setIncludeBulkData(IncludeBulkData.YES);
+          dicomInputStream.setBulkDataDescriptor(BulkDataDescriptor.PIXELDATA);
+          metadata = dicomInputStream.getFileMetaInformation();
+
+          // Update UID in metadata.
+          regenUID(metadata, Tag.MediaStorageSOPInstanceUID);
+
+          // Overwrite transfer syntax if PixelData is to be removed.
+          String ts = metadata.getString(Tag.TransferSyntaxUID);
+          if (shouldRemoveTag(toTagID("PixelData"))
+              && (TransferSyntaxType.forUID(ts) != TransferSyntaxType.NATIVE)) {
+            metadata.setString(Tag.TransferSyntaxUID, VR.UI, UID.ExplicitVRLittleEndian);
+          }
+        } catch (Exception e) {
+          throw new IOException("Failed to initialize redactor", e);
+        }
+
+        boolean firstDataset = true;
+        boolean lastDataset = false;
+        while (!lastDataset) {
+          try {
+            dicomInputStream.mark(BATCH_SIZE);
+            dataset = dicomInputStream.readDataset(BATCH_SIZE, -1);
+          } catch (EOFException e) {
+            dicomInputStream.reset();
+            dataset = dicomInputStream.readDataset(-1, -1);
+            lastDataset = true;
+          }
+
+          try {
+            dataset.accept(visitor, false);
+          } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to redact one or more tags", e);
+          }
+
+          if (firstDataset) {
+            firstDataset = false;
+            dicomOutputStream.writeDataset(metadata, dataset);
+          } else {
+            dicomOutputStream.writeDataset(null, dataset);
+          }
+        }
+      }
+    }
+  }
+}

--- a/offline_tools/redactor/lib/src/test/java/com/google/cloud/healthcare/deid/redactor/DicomRedactorTest.java
+++ b/offline_tools/redactor/lib/src/test/java/com/google/cloud/healthcare/deid/redactor/DicomRedactorTest.java
@@ -73,7 +73,7 @@ public final class DicomRedactorTest {
 
   private IDicomRedactor createDicomRedactor(DicomConfig config, String prefix) throws Exception {
     try {
-      if(prefix != null) {
+      if (prefix != null) {
         return (IDicomRedactor) implementationClass.getConstructor(DicomConfig.class, String.class)
             .newInstance(config, prefix);
       } else {
@@ -89,7 +89,6 @@ public final class DicomRedactorTest {
       }
     }
   }
-
 
   private void redactAndVerify(Attributes metadata, Attributes inData, Attributes expectedMetadata,
       Attributes expectedData, IDicomRedactor redactor) throws Exception {


### PR DESCRIPTION
There are no interface changes for pre-existing usage.

New streaming implementation parses last dataset twice (fails as fixed length with EOF, then reads to the end), which is why I decided to keep it separate.